### PR TITLE
Use cross browser compatible string sort

### DIFF
--- a/src/components/BreweryList/index.tsx
+++ b/src/components/BreweryList/index.tsx
@@ -27,7 +27,7 @@ const BreweryList = observer((props: any) => {
              brewery.lng < props.mapState.viewboxRight &&
              brewery.lng > props.mapState.viewboxLeft;
     })
-    .sort((a: any, b: any) => a.name > b.name);
+    .sort((a: any, b: any) => a.localeCompare(b));
 
   return (
     <Outer full scroll>

--- a/src/components/BreweryListSmallScreen/index.tsx
+++ b/src/components/BreweryListSmallScreen/index.tsx
@@ -27,7 +27,7 @@ const BreweryList = observer((props: any) => {
              brewery.lng < props.mapState.viewboxRight &&
              brewery.lng > props.mapState.viewboxLeft;
     })
-    .sort((a: any, b: any) => a.name > b.name);
+    .sort((a: any, b: any) => a.localeCompare(b));
 
   return (
     <Outer full scroll>


### PR DESCRIPTION
The previous sort used (a > b) which doesn't behave as expected in
Chrome but works in Firefox. Instead, let's just use
String.prototype.localeCompare() which should work in all browsers.